### PR TITLE
F17/keywords to description

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# https://dashboard.cohere.com/api-keys
+COHERE_API_KEY=

--- a/client/api.ts
+++ b/client/api.ts
@@ -4,11 +4,8 @@ import { ICard } from '../models/card.ts'
 const rootUrl = '/api/v1'
 
 export async function getKeywords(username: string) {
-  const result = request
-    .get(`${rootUrl}/keywords?username=${username}`)
-    .then((res) => res.body.keywords)
-    .catch(logError)
-  return result
+  const result = await request.get(`${rootUrl}/keywords?username=${username}`)
+  return result.body
 }
 
 export async function getCards(keywords: string): Promise<ICard[]> {

--- a/client/components/CardGallery.tsx
+++ b/client/components/CardGallery.tsx
@@ -7,7 +7,6 @@ function CardGallery() {
   return (
     <>
       <div className=" text-xl mt-2">Card Gallery</div>
-      <div>Cards for everyone</div>
       <div className="flex flex-wrap gap-2">
         {cards.data?.map((card) => {
           return <Card key={card.id} card={card} />

--- a/client/components/FriendInput.tsx
+++ b/client/components/FriendInput.tsx
@@ -12,7 +12,7 @@ function Keywords() {
         <div>{scraper.data?.join(', ')}</div>
       )}
     </>
-  );
+  )
 }
 
 function FriendInput() {

--- a/client/components/FriendInput.tsx
+++ b/client/components/FriendInput.tsx
@@ -2,14 +2,17 @@ import { useCards, useScraper } from '../hooks'
 
 function Keywords() {
   const scraper = useScraper('pooleypoo')
-
   return (
     <>
-      <div className="text-xl mt-2 gap-2">Keywords</div>
       {scraper.isLoading ? (
         <div>Loading...</div>
       ) : (
-        <div>{scraper.data?.join(', ')}</div>
+        <>
+          <div className="text-2xl">Keywords</div>
+          <div>{JSON.stringify(scraper.data.keywords)}</div>
+          <div className="text-2xl">Description</div>
+          <div>{JSON.stringify(scraper.data.description)}</div>
+        </>
       )}
     </>
   )

--- a/client/components/FriendInput.tsx
+++ b/client/components/FriendInput.tsx
@@ -9,9 +9,9 @@ function Keywords() {
       ) : (
         <>
           <div className="text-2xl">Keywords</div>
-          <div>{JSON.stringify(scraper.data.keywords)}</div>
+          <div>{JSON.stringify(scraper.data?.keywords || 'Error')}</div>
           <div className="text-2xl">Description</div>
-          <div>{JSON.stringify(scraper.data.description)}</div>
+          <div>{JSON.stringify(scraper.data?.description || 'Error')}</div>
         </>
       )}
     </>

--- a/client/hooks.ts
+++ b/client/hooks.ts
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query'
 import * as API from './api.ts'
 
 export function useScraper(username: string) {
-
   const query = useQuery({
     queryKey: ['scraper'],
     queryFn: () => API.getKeywords(username),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "cohere-ai": "^7.9.0",
         "dotenv": "^10.0.0",
         "express": "^4.17.2",
         "express-jwt": "^7.7.5",
@@ -56,7 +57,6 @@
         "superagent": "7.1.1",
         "supertest": "^6.2.2",
         "tailwindcss": "^3.4.1",
-        "tsx": "^3.12.7",
         "typescript": "^5.1.6",
         "vite": "^4.4.9",
         "vitest": "^0.34.4"
@@ -2702,8 +2702,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/autoprefixer": {
       "version": "10.4.18",
@@ -2979,12 +2978,6 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3250,6 +3243,32 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/cohere-ai": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/cohere-ai/-/cohere-ai-7.9.0.tgz",
+      "integrity": "sha512-iHPG4dule+nMlw88Xe0USGZbLlXuRC4yvOvfCqoEdW9tHOc0vkiPfiyjBalDcPKj9KEvWZfii84kyN5HyTMySw==",
+      "dependencies": {
+        "form-data": "4.0.0",
+        "js-base64": "3.7.2",
+        "node-fetch": "2.7.0",
+        "qs": "6.11.2",
+        "url-join": "4.0.1"
+      }
+    },
+    "node_modules/cohere-ai/node_modules/qs": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3286,7 +3305,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3665,7 +3683,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4978,7 +4995,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -5199,18 +5215,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-tsconfig": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.3.tgz",
-      "integrity": "sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==",
-      "dev": true,
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/getopts": {
@@ -6166,6 +6170,11 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7064,6 +7073,44 @@
       "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
       "engines": {
         "node": "^16 || ^18 || >= 20"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-gyp": {
@@ -8431,15 +8478,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -8881,15 +8919,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.1.0.tgz",
@@ -8897,16 +8926,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/spdx-correct": {
@@ -9804,412 +9823,6 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
-    "node_modules/tsx": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-3.14.0.tgz",
-      "integrity": "sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==",
-      "dev": true,
-      "dependencies": {
-        "esbuild": "~0.18.20",
-        "get-tsconfig": "^4.7.2",
-        "source-map-support": "^0.5.21"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/android-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
-      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/tsx/node_modules/esbuild": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
-      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/android-arm": "0.18.20",
-        "@esbuild/android-arm64": "0.18.20",
-        "@esbuild/android-x64": "0.18.20",
-        "@esbuild/darwin-arm64": "0.18.20",
-        "@esbuild/darwin-x64": "0.18.20",
-        "@esbuild/freebsd-arm64": "0.18.20",
-        "@esbuild/freebsd-x64": "0.18.20",
-        "@esbuild/linux-arm": "0.18.20",
-        "@esbuild/linux-arm64": "0.18.20",
-        "@esbuild/linux-ia32": "0.18.20",
-        "@esbuild/linux-loong64": "0.18.20",
-        "@esbuild/linux-mips64el": "0.18.20",
-        "@esbuild/linux-ppc64": "0.18.20",
-        "@esbuild/linux-riscv64": "0.18.20",
-        "@esbuild/linux-s390x": "0.18.20",
-        "@esbuild/linux-x64": "0.18.20",
-        "@esbuild/netbsd-x64": "0.18.20",
-        "@esbuild/openbsd-x64": "0.18.20",
-        "@esbuild/sunos-x64": "0.18.20",
-        "@esbuild/win32-arm64": "0.18.20",
-        "@esbuild/win32-ia32": "0.18.20",
-        "@esbuild/win32-x64": "0.18.20"
-      }
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -10457,6 +10070,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "node_modules/url-parse": {
       "version": "1.5.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.36",
         "prettier": "2.6.1",
-        "react": "^18.0.2",
+        "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.11.2",
         "regenerator-runtime": "^0.13.7",
@@ -57,6 +57,8 @@
         "superagent": "7.1.1",
         "supertest": "^6.2.2",
         "tailwindcss": "^3.4.1",
+        "tsc": "^2.0.4",
+        "tsx": "^4.7.1",
         "typescript": "^5.1.6",
         "vite": "^4.4.9",
         "vitest": "^0.34.4"
@@ -5217,6 +5219,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.3.tgz",
+      "integrity": "sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/getopts": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
@@ -8478,6 +8492,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -9778,6 +9801,15 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
+    "node_modules/tsc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/tsc/-/tsc-2.0.4.tgz",
+      "integrity": "sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -9821,6 +9853,25 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.1.tgz",
+      "integrity": "sha512-8d6VuibXHtlN5E3zFkgY8u4DX7Y3Z27zvvPKVmLon/D4AjuKzarkUBTLDBgj9iTQ0hg5xM7c/mYiRVM+HETf0g==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.19.10",
+        "get-tsconfig": "^4.7.2"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.36",
     "prettier": "2.6.1",
-    "react": "^18.0.2",
+    "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.2",
     "regenerator-runtime": "^0.13.7",
@@ -77,6 +77,8 @@
     "superagent": "7.1.1",
     "supertest": "^6.2.2",
     "tailwindcss": "^3.4.1",
+    "tsc": "^2.0.4",
+    "tsx": "^4.7.1",
     "typescript": "^5.1.6",
     "vite": "^4.4.9",
     "vitest": "^0.34.4"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     ]
   },
   "dependencies": {
+    "cohere-ai": "^7.9.0",
     "dotenv": "^10.0.0",
     "express": "^4.17.2",
     "express-jwt": "^7.7.5",
@@ -76,7 +77,6 @@
     "superagent": "7.1.1",
     "supertest": "^6.2.2",
     "tailwindcss": "^3.4.1",
-    "tsx": "^3.12.7",
     "typescript": "^5.1.6",
     "vite": "^4.4.9",
     "vitest": "^0.34.4"

--- a/server/routes/keywords.ts
+++ b/server/routes/keywords.ts
@@ -1,5 +1,9 @@
 import express from 'express'
-import { parseToKeywords, scrapeProfile } from '../services/scraper'
+import {
+  parseToDescription,
+  parseToKeywords,
+  scrapeProfile,
+} from '../services/scraper'
 // import { JwtRequest } from '../auth0.ts'
 
 const router = express.Router()
@@ -22,11 +26,10 @@ router.get('/', async (req, res) => {
     const keywords = await parseToKeywords(profileData)
 
     // Parse to description object to generate images with
-    // TODO: use parseToDescription()
+    const description = parseToDescription(keywords)
 
     // mock returned keywords
     res.json({ keywords })
-
   } catch (error) {
     console.error(error)
     res.status(500).send('Something went wrong')

--- a/server/routes/keywords.ts
+++ b/server/routes/keywords.ts
@@ -1,9 +1,6 @@
 import express from 'express'
-import {
-  parseToDescription,
-  parseToKeywords,
-  scrapeProfile,
-} from '../services/scraper'
+import { parseToKeywords, scrapeProfile } from '../services/scraper'
+import { parseToDescription } from '../services/cohere'
 // import { JwtRequest } from '../auth0.ts'
 
 const router = express.Router()
@@ -26,10 +23,10 @@ router.get('/', async (req, res) => {
     const keywords = await parseToKeywords(profileData)
 
     // Parse to description object to generate images with
-    const description = parseToDescription(keywords)
+    const description = await parseToDescription(keywords)
 
     // mock returned keywords
-    res.json({ keywords })
+    res.json({ keywords, description })
   } catch (error) {
     console.error(error)
     res.status(500).send('Something went wrong')

--- a/server/services/cohere.ts
+++ b/server/services/cohere.ts
@@ -3,6 +3,10 @@ import { CohereClient } from 'cohere-ai'
 
 dotenv.config()
 
+if (!process.env.COHERE_API_KEY) {
+  throw new Error('Missing COHERE_API_KEY')
+}
+
 const cohere = new CohereClient({
   token: process.env.COHERE_API_KEY,
 })

--- a/server/services/cohere.ts
+++ b/server/services/cohere.ts
@@ -9,48 +9,43 @@ const cohere = new CohereClient({
 
 const keywords = [
   'streetart',
-  'Flinders Street',
-  'Thailand',
   'final days',
-  'Wat Phra That Doi Suthep',
   'temple',
   'Big Buddha',
   'lookout',
-  'Tham Luang Cave',
   'rescue',
   'white temple',
   'art project',
-  'Chiang Rai',
   'red panda',
   'monkey',
   'utes',
-  'Chiang Mai',
 ]
 
-async function generate() {
-  const prediction = await cohere.generate({
-    prompt: `take this list of keywords about a person, and return a descriptive profile about them: ${keywords.join(
-      ', '
-    )}`,
-    maxTokens: 500,
+async function generate(keywords: string[]) {
+  const instructions =
+    '## Instructions: \nTake this list of words about a person, and return a descriptive profile about them.\n' +
+    'DO: output in JSON format, using bullet points with the headings "interests", "personality", "locations".\n' +
+    'DO NOT: ask any questions, just output the descriptive profile.\n\n'
+
+  const input = '## Input list: \n' + keywords.join(', ') + '\n\n'
+
+  const message = instructions + input
+
+  const response = await cohere.generate({
+    prompt: message,
   })
 
-  console.log('Received prediction: ', prediction.generations[0].text)
-
-  const output = await cohere.generate({
-    prompt: `output this in a short form machine readable format, for example just bullet pointed json with relevant headings: ${prediction.generations[0].text}`,
-    maxTokens: 500,
-  })
-
-  console.log('Received output: ', output.generations[0].text)
+  const result = JSON.parse(response.generations[0].text)
+  console.log(result)
+  return result
 }
 
-generate()
+generate(keywords)
 
 // To test:
 // npx tsx ./server/services/cohere.ts
 
-// Received prediction:   Active and creative, they have a keen interest in street art and temples, and has visited many renowned places of worship in Bangkok and Chiang Mai, including the Wat Phra That Doi Suthep and the White Temple. They have an artistic side and has perhaps undertaken an art project themselves! They love animals and have had many memorable encounters with monkeys and pandas. They also has an interest in the great outdoors, and has spent time at Flinders Street and other scenic lookouts, and has visited the Tham Luang Cave during happier final days.
+// Received response:   Active and creative, they have a keen interest in street art and temples, and has visited many renowned places of worship in Bangkok and Chiang Mai, including the Wat Phra That Doi Suthep and the White Temple. They have an artistic side and has perhaps undertaken an art project themselves! They love animals and have had many memorable encounters with monkeys and pandas. They also has an interest in the great outdoors, and has spent time at Flinders Street and other scenic lookouts, and has visited the Tham Luang Cave during happier final days.
 
 // This person is probably from Australia and has a curious, adventurous side who enjoys exploring the world and appreciating different cultures and forms of art.They lead a balanced life, soaking in serene temples and buzzing streets filled with vibrant art and bustling energy.
 // Received output: ```json

--- a/server/services/cohere.ts
+++ b/server/services/cohere.ts
@@ -1,0 +1,64 @@
+import dotenv from 'dotenv'
+import { CohereClient } from 'cohere-ai'
+
+dotenv.config()
+
+const cohere = new CohereClient({
+  token: process.env.COHERE_API_KEY,
+})
+
+const keywords = [
+  'streetart',
+  'Flinders Street',
+  'Thailand',
+  'final days',
+  'Wat Phra That Doi Suthep',
+  'temple',
+  'Big Buddha',
+  'lookout',
+  'Tham Luang Cave',
+  'rescue',
+  'white temple',
+  'art project',
+  'Chiang Rai',
+  'red panda',
+  'monkey',
+  'utes',
+  'Chiang Mai',
+]
+
+async function generate() {
+  const prediction = await cohere.generate({
+    prompt: `take this list of keywords about a person, and return a descriptive profile about them: ${keywords.join(
+      ', '
+    )}`,
+    maxTokens: 500,
+  })
+
+  console.log('Received prediction: ', prediction.generations[0].text)
+
+  const output = await cohere.generate({
+    prompt: `output this in a short form machine readable format, for example just bullet pointed json with relevant headings: ${prediction.generations[0].text}`,
+    maxTokens: 500,
+  })
+
+  console.log('Received output: ', output.generations[0].text)
+}
+
+generate()
+
+// To test:
+// npx tsx ./server/services/cohere.ts
+
+// Received prediction:   Active and creative, they have a keen interest in street art and temples, and has visited many renowned places of worship in Bangkok and Chiang Mai, including the Wat Phra That Doi Suthep and the White Temple. They have an artistic side and has perhaps undertaken an art project themselves! They love animals and have had many memorable encounters with monkeys and pandas. They also has an interest in the great outdoors, and has spent time at Flinders Street and other scenic lookouts, and has visited the Tham Luang Cave during happier final days.
+
+// This person is probably from Australia and has a curious, adventurous side who enjoys exploring the world and appreciating different cultures and forms of art.They lead a balanced life, soaking in serene temples and buzzing streets filled with vibrant art and bustling energy.
+// Received output: ```json
+// {
+// "interests": ["Street Art", "Temples", "Art", "Animals", "The Great Outdoors"],
+// "locations": ["Bangkok", "Chiang Mai", "Wat Phra That Doi Suthep", "White Temple", "Flinders Street", "Tham Luang Cave"],
+// "personal": "Active, creative, artistic, adventurous, curious, balanced"
+// }
+// ```
+
+// Let me know if you'd like me to extract any more information from the given text!

--- a/server/services/cohere.ts
+++ b/server/services/cohere.ts
@@ -21,7 +21,7 @@ const keywords = [
   'utes',
 ]
 
-async function generate(keywords: string[]) {
+export async function parseToDescription(keywords: string[]) {
   const instructions =
     '## Instructions: \nTake this list of words about a person, and return a descriptive profile about them.\n' +
     'DO: output in JSON format, using bullet points with the headings "interests", "personality", "locations".\n' +
@@ -36,24 +36,5 @@ async function generate(keywords: string[]) {
   })
 
   const result = JSON.parse(response.generations[0].text)
-  console.log(result)
   return result
 }
-
-generate(keywords)
-
-// To test:
-// npx tsx ./server/services/cohere.ts
-
-// Received response:   Active and creative, they have a keen interest in street art and temples, and has visited many renowned places of worship in Bangkok and Chiang Mai, including the Wat Phra That Doi Suthep and the White Temple. They have an artistic side and has perhaps undertaken an art project themselves! They love animals and have had many memorable encounters with monkeys and pandas. They also has an interest in the great outdoors, and has spent time at Flinders Street and other scenic lookouts, and has visited the Tham Luang Cave during happier final days.
-
-// This person is probably from Australia and has a curious, adventurous side who enjoys exploring the world and appreciating different cultures and forms of art.They lead a balanced life, soaking in serene temples and buzzing streets filled with vibrant art and bustling energy.
-// Received output: ```json
-// {
-// "interests": ["Street Art", "Temples", "Art", "Animals", "The Great Outdoors"],
-// "locations": ["Bangkok", "Chiang Mai", "Wat Phra That Doi Suthep", "White Temple", "Flinders Street", "Tham Luang Cave"],
-// "personal": "Active, creative, artistic, adventurous, curious, balanced"
-// }
-// ```
-
-// Let me know if you'd like me to extract any more information from the given text!

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -4,8 +4,6 @@
  * @returns An array of strings representing the scraped profile data.
  */
 export function scrapeProfile(username: string): string[] {
-  console.log('Scraping: ', username)
-
   // Return the scraped data
   // TODO: replace mock data
   return [
@@ -26,8 +24,6 @@ export function scrapeProfile(username: string): string[] {
  * @return {string[]} An array of keywords extracted from the profile data.
  */
 export function parseToKeywords(profileData: string[]) {
-  console.log('Parsing: ', profileData)
-
   // Return the keywords array
   // TODO: replace mock data
   return [
@@ -49,30 +45,4 @@ export function parseToKeywords(profileData: string[]) {
     'utes',
     'Chiang Mai',
   ]
-}
-
-/**
- * Retrieves person description data based on the provided keywords.
- *
- * @param {string[]} keywords - An array of keywords to search for.
- * @return {Object} - An object containing ??
- */
-export function parseToDescription(keywords: string[]) {
-  console.log('Parsing: ', keywords)
-
-  // TODO: replace mock data
-  // Not sure what format we need it in to pass to the image generation API
-  // TODO: Define an interface/type for the return data
-  return {
-    interests: ['Travel', 'Art', 'Culture', 'Adventure', 'Wildlife'],
-    traits: ['Art Enthusiast', 'Explorer', 'Culturally Curious', 'Adventurous'],
-    focusAreas: ['Street Art', 'Historical Landmarks', 'Wildlife Observation'],
-    regionsVisited: ['Southeast Asia', 'Thailand'],
-    noteworthyExperiences: [
-      'Exploring urban street art',
-      'Visiting significant temples and cultural sites',
-      'Adventurous excursions to caves and lookout points',
-      'Observing exotic wildlife',
-    ],
-  }
 }

--- a/server/services/scraper.ts
+++ b/server/services/scraper.ts
@@ -4,21 +4,20 @@
  * @returns An array of strings representing the scraped profile data.
  */
 export function scrapeProfile(username: string): string[] {
-    console.log("Scraping: ", username);
+  console.log('Scraping: ', username)
 
-    // Return the scraped data
-    // TODO: replace mock data
-    return [
-        "some #streetart spotted around Flinders St",
-        "Final few days in Thailand",
-        "Wat Phra That Doi Suthep",
-        "Big Buddha (66 floors to the bindi spot/lookout) and Tham Luang Cave where the thai kids got rescued",
-        "the white temple (some guy's art project) in Chiang Rai",
-        "A red panda, a monkey and a bunch of rust bucket utes, not that you care, chur",
-        "Sorry not sorry, more #streetart discoveries in #chiangmai"
-    ];
-};
-
+  // Return the scraped data
+  // TODO: replace mock data
+  return [
+    'some #streetart spotted around Flinders St',
+    'Final few days in Thailand',
+    'Wat Phra That Doi Suthep',
+    'Big Buddha (66 floors to the bindi spot/lookout) and Tham Luang Cave where the thai kids got rescued',
+    "the white temple (some guy's art project) in Chiang Rai",
+    'A red panda, a monkey and a bunch of rust bucket utes, not that you care, chur',
+    'Sorry not sorry, more #streetart discoveries in #chiangmai',
+  ]
+}
 
 /**
  * Parses the given profile data and returns an array of keywords.
@@ -27,33 +26,30 @@ export function scrapeProfile(username: string): string[] {
  * @return {string[]} An array of keywords extracted from the profile data.
  */
 export function parseToKeywords(profileData: string[]) {
-    console.log("Parsing: ", profileData)
+  console.log('Parsing: ', profileData)
 
-    // Return the keywords array
-    // TODO: replace mock data
-    return [
-        'streetart',
-        'Flinders Street',
-        'Thailand',
-        'final days',
-        'Wat Phra That Doi Suthep',
-        'temple',
-        'Big Buddha',
-        'lookout',
-        'Tham Luang Cave',
-        'rescue',
-        'white temple',
-        'art project',
-        'Chiang Rai',
-        'red panda',
-        'monkey',
-        'utes',
-        'Chiang Mai'
-    ]
-
-};
-
-
+  // Return the keywords array
+  // TODO: replace mock data
+  return [
+    'streetart',
+    'Flinders Street',
+    'Thailand',
+    'final days',
+    'Wat Phra That Doi Suthep',
+    'temple',
+    'Big Buddha',
+    'lookout',
+    'Tham Luang Cave',
+    'rescue',
+    'white temple',
+    'art project',
+    'Chiang Rai',
+    'red panda',
+    'monkey',
+    'utes',
+    'Chiang Mai',
+  ]
+}
 
 /**
  * Retrieves person description data based on the provided keywords.
@@ -62,22 +58,21 @@ export function parseToKeywords(profileData: string[]) {
  * @return {Object} - An object containing ??
  */
 export function parseToDescription(keywords: string[]) {
-    console.log("Parsing: ", keywords)
+  console.log('Parsing: ', keywords)
 
-    // TODO: replace mock data
-    // Not sure what format we need it in to pass to the image generation API
-    // TODO: Define an interface/type for the return data
-    return {
-        interests: ['Travel', 'Art', 'Culture', 'Adventure', 'Wildlife'],
-        traits: ['Art Enthusiast', 'Explorer', 'Culturally Curious', 'Adventurous'],
-        focusAreas: ['Street Art', 'Historical Landmarks', 'Wildlife Observation'],
-        regionsVisited: ['Southeast Asia', 'Thailand'],
-        noteworthyExperiences: [
-            'Exploring urban street art',
-            'Visiting significant temples and cultural sites',
-            'Adventurous excursions to caves and lookout points',
-            'Observing exotic wildlife'
-        ]
-    };
-
+  // TODO: replace mock data
+  // Not sure what format we need it in to pass to the image generation API
+  // TODO: Define an interface/type for the return data
+  return {
+    interests: ['Travel', 'Art', 'Culture', 'Adventure', 'Wildlife'],
+    traits: ['Art Enthusiast', 'Explorer', 'Culturally Curious', 'Adventurous'],
+    focusAreas: ['Street Art', 'Historical Landmarks', 'Wildlife Observation'],
+    regionsVisited: ['Southeast Asia', 'Thailand'],
+    noteworthyExperiences: [
+      'Exploring urban street art',
+      'Visiting significant temples and cultural sites',
+      'Adventurous excursions to caves and lookout points',
+      'Observing exotic wildlife',
+    ],
+  }
 }


### PR DESCRIPTION
Added a `cohere` service to the backend that takes a list of keywords as input and sends that to Cohere's API and converts those to a descriptive profile. 

Note: Requires a [Cohere API key](https://dashboard.cohere.com/api-keys), store in the `.env` file (rename and edit the `.env.example` file)

The output is displayed on the front end using the scraper hook.

Closes #17 